### PR TITLE
Generate type definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ test
 .antlr
 *.interp
 *.tokens
+index.js.*
+index.d.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "abapcdsgrammar",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "0.0.5",
   "description": "Grammar for ABAP CDS",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "npm run antlr4ts; tsc -p ./tsconfig.test.json; node test/test.js",
     "build": "npm run clean; npm run antlr4ts; tsc -p ./tsconfig.json",
-    "clean": "rm -rdf dist test .antlr",
+    "clean": "rm -rdf dist test .antlr index.d.* index.js.*",
     "publish": "npm run clean; npm run build; npm publish",
     "antlr4ts": "antlr4ts -visitor ./ABAPCDS.g4 -o dist"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,8 @@
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "./dist",                        /* Redirect output structure to the directory. */


### PR DESCRIPTION
The current npm module confuses ts-jest, which tries (and fails) to compile ABAPCDSLexer.ts

Generating the type definitions and removing the .ts files from the package fixes it (perhaps I could make it work configuring jest too, but I thought this is nicer for the next guy)

Cheers
Marcello