### PR TITLE
Fixes #28 keywords in annotation identifiers

### DIFF
--- a/ABAPCDS.g4
+++ b/ABAPCDS.g4
@@ -98,6 +98,56 @@ ANNOTATIONSEPERATOR
 STRING
    : '\'' (~'\'' | '\'\'')* '\''
    ;
+keyword
+    :DEFINE
+    |VIEW
+    |AS
+    |SELECT
+    |FROM
+    |WHERE
+    |GROUPBY
+    |HAVING
+    |UNION
+    |ALL
+    |BOOLEANLITERAL
+    |KEY
+    |CASE
+    |WHEN
+    |THEN
+    |ELSE
+    |END
+    |CAST
+    |DISTINCT
+    |TO
+    |WITH
+    |PARAMETERS
+    |DEFAULT
+    |FILTER
+    |ASSOCIATION
+    |ON
+    |NOT
+    |AND
+    |OR
+    |BETWEEN
+    |LIKE
+    |ESCAPE
+    |IS
+    |NULL
+    |INNER
+    |JOIN
+    |OUTER
+    |LEFT
+    |RIGHT
+    |ONE
+    |MANY
+    |CROSS
+    |MAX
+    |MIN
+    |AVG
+    |SUM
+    |COUNT
+    |RETURNS
+    ;
 
 statement
     :   annotation
@@ -298,10 +348,7 @@ annotation_value
 
 annotation_identifier
     : IDENTIFIER
-    | ASSOCIATION
-    | TO
-    | FILTER
-    | FROM
+    | keyword
     ;
 
 subannos

--- a/examples/default_as_identifier.asddls
+++ b/examples/default_as_identifier.asddls
@@ -1,0 +1,11 @@
+@AbapCatalog.sqlViewName: 'ZAPIDUMMY_DDEFSV'
+@AbapCatalog.compiler.compareFilter: true
+@AbapCatalog.preserveKey: true
+@AccessControl.authorizationCheck: #CHECK
+@EndUserText.label: 'data definition test'
+@Metadata.allowExtensions: true
+define view ZAPIDUMMY_datadef as select from e070{
+    trkorr,
+    @Aggregation.default: #NONE
+    as4user
+}


### PR DESCRIPTION
Probably overkill to add all keywords but I think it's correct
already had exception like @from, @to (or was it @foo.from ? never mind) 