### PR TITLE
exclude typescript files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,8 @@ test
 *.interp
 *.tokens
 .antlr
+ABAPCDSLexer.ts*
+ABAPCDSListener.ts*
+ABAPCDSParser.ts*
+ABAPCDSVisitor.ts*
+index.ts


### PR DESCRIPTION
Including the .ts files in dist screws up jest, as includes .ts files from modules which is excluded in tsconfig.

Probably a jest/babel bug but still...
Anyway what one really needs are the .d.ts

This was supposed to be in a previous PR but I forgot to push :(